### PR TITLE
bugfix: random label assignment

### DIFF
--- a/MiniImagenet.py
+++ b/MiniImagenet.py
@@ -154,6 +154,7 @@ class MiniImagenet(Dataset):
 		# query_y: [querysz]
 		# unique: [n-way], sorted
 		unique = np.unique(support_y)
+		random.shuffle(unique)
 		# relative means the label ranges from 0 to n-way
 		support_y_relative = np.zeros(self.setsz)
 		query_y_relative = np.zeros(self.querysz)


### PR DESCRIPTION
np.unique(support_y) will sort the unique values. Hence, the same label was assigned to the same class more often than random.